### PR TITLE
Replaced rawgit.com urls with combinatronics.com urls.

### DIFF
--- a/templates/index.tpl
+++ b/templates/index.tpl
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge;chrome=1">
     <title> sliders list </title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="https://cdn.rawgit.com/mblode/marx/master/css/marx.min.css" />
+    <link rel="stylesheet" href="https://cdn.combinatronics.com/mblode/marx/master/css/marx.min.css" />
   </head>
 
   <body>


### PR DESCRIPTION
Combinatronics.com is a drop in replacement for rawgit.com which is EOL.